### PR TITLE
node.h include path was incorrect

### DIFF
--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -1,5 +1,5 @@
 #include <v8.h>
-#include <nodejs/src/node.h>
+#include <node.h>
 
 #include <systemd/sd-daemon.h>
 


### PR DESCRIPTION
So the extension couldn't be built with node 0.10.24
