### PR TITLE
Fix TypeError: Cannot use 'in' operator to search for 'systemd' in 3000

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ var Pipe = process.binding('pipe_wrap').Pipe;
 
 var origListen = net.Server.prototype.listen;
 net.Server.prototype.listen = function(arg, cb) {
-    if (arg && 'systemd' in arg) {
+    if (typeof(arg) == 'object' && 'systemd' in arg) {
     
         if (arg.systemd >= exports.listen_fds()) {
             this.emit('listening', new Error('bad socket activation descriptor'));
@@ -67,7 +67,7 @@ net.Server.prototype.listen = function(arg, cb) {
             return this.listen({fd: exports.LISTEN_FDS_START + arg.systemd, listened: true}, cb);
         }
         
-    } else if (arg && 'fd' in arg && arg.listened) {
+    } else if (typeof(arg) == 'object' && 'fd' in arg && arg.listened) {
         if (cb) this.once('listening', cb);
         
         this._handle = new Pipe();


### PR DESCRIPTION
Custom net.Server.prototype.listen method crashes when numeric port is passed to it.

May 18 03:44:14 buzby node[2085]: /srv/web-gui/node_app/node_modules/sd-daemon/index.js:61
May 18 03:44:14 buzby node[2085]: if (arg && 'systemd' in arg) {
May 18 03:44:14 buzby node[2085]: ^
May 18 03:44:14 buzby node[2085]: TypeError: Cannot use 'in' operator to search for 'systemd' in 3000
May 18 03:44:14 buzby node[2085]: at Server.net.Server.listen (/srv/web-gui/node_app/node_modules/sd-daemon/index...61:29)
May 18 03:44:14 buzby node[2085]: at Function.express.application.listen (/srv/web-gui/node_app/node_modules/expr...15:33)
May 18 03:44:14 buzby node[2085]: at /srv/web-gui/node_app/app.js:162:17
May 18 03:44:14 buzby node[2085]: at Statement.<anonymous> (/srv/web-gui/node_app/core/incidentManager.js:76:28)
