### PR TITLE
Use libystemd-daemon with pkg-config to work on fedora 19

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -4,7 +4,7 @@
             "target_name": "daemon",
             "sources": [ "src/daemon.cc" ],
             "libraries": [
-                "<!@(pkg-config --libs-only-l libsystemd)"
+                "<!@(pkg-config --libs-only-l libsystemd-daemon)"
             ]
         },
         {


### PR DESCRIPTION
This still works on systems with newer systemd as the seperate
libsystemd-*.pc files are still installed.
