### PR TITLE
Compatible with Node 0.12.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build
 daemon.node
 debian/files
 debian/node-sd-daemon*
+node_modules/

--- a/binding.gyp
+++ b/binding.gyp
@@ -3,6 +3,9 @@
         {
             "target_name": "daemon",
             "sources": [ "src/daemon.cc" ],
+            "include_dirs" : [
+                "<!(node -e \"require('nan')\")"
+            ],
             "libraries": [
                 "<!@(pkg-config --silence-errors --libs-only-l libsystemd || pkg-config --silence-errors --libs-only-l libsystemd-daemon)"
             ]

--- a/package.json
+++ b/package.json
@@ -1,29 +1,28 @@
 {
-    "name": "sd-daemon",
-    "version": "0.4.0",
-    
-    "description": "Bindings for libsystemd-daemon",
-    "homepage": "https://github.com/victorenator/node-sd-daemon",
-    
-    "license": "LGPL-2.1+",
-    
-    "author": {
-        "name": "Viktar Vauchkevich",
-        "email": "victorenator@gmail.com"
-    },
-            
-    "keywords": ["systemd", "daemon"],
-    
-    "scripts": {
-        "install": "node-gyp rebuild"
-    },
-    
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/victorenator/node-sd-daemon.git"
-    },
-
-    "engines": {
-        "nodejs": ">= 0.8"
-    }
+  "name": "sd-daemon",
+  "version": "0.5.0",
+  "description": "Bindings for libsystemd-daemon",
+  "homepage": "https://github.com/victorenator/node-sd-daemon",
+  "license": "LGPL-2.1+",
+  "author": {
+    "name": "Viktar Vauchkevich",
+    "email": "victorenator@gmail.com"
+  },
+  "keywords": [
+    "systemd",
+    "daemon"
+  ],
+  "scripts": {
+    "install": "node-gyp rebuild"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/victorenator/node-sd-daemon.git"
+  },
+  "engines": {
+    "nodejs": ">= 0.8"
+  },
+  "dependencies": {
+    "nan": "^1.6.2"
+  }
 }

--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -1,36 +1,41 @@
-#include <v8.h>
 #include <node.h>
+#include <nan.h>
 
 #include <systemd/sd-daemon.h>
 
-namespace daemon {
+using v8::FunctionTemplate;
+using v8::Handle;
+using v8::Number;
+using v8::Object;
+using v8::String;
 
-    v8::Handle<v8::Value> booted(const v8::Arguments& args) {
-        v8::HandleScope scope;
+NAN_METHOD(booted) {
+    NanScope();
         
-        const int res = sd_booted();
-        return scope.Close(v8::Integer::New(res));
-    }
+    const int res = sd_booted();
+
+    NanReturnValue(NanNew<Number>(res));
+}
     
-    v8::Handle<v8::Value> notify(const v8::Arguments& args) {
-        v8::HandleScope scope;
+NAN_METHOD(notify) {
+    NanScope();
         
-        if (!(args.Length() == 1 && args[0]->IsString())) {
-            v8::ThrowException(v8::Exception::TypeError(v8::String::New("Expected one string argument")));
-            return scope.Close(v8::Undefined());
-        }
-        
-        v8::String::Utf8Value state(args[0]);
-        
-        const int res = sd_notify(0, *state);
-        return scope.Close(v8::Integer::New(res));
+    if (!(args.Length() == 1 && args[0]->IsString())) {
+        NanThrowTypeError("expected one string argument");
+        NanReturnUndefined();
     }
+        
+    Utf8Value state(args[0]);
+        
+    const int res = sd_notify(0, *state);
 
-    void init(v8::Handle<v8::Object> exports) {
-        exports->Set(v8::String::NewSymbol("notify"), v8::FunctionTemplate::New(notify)->GetFunction());
-        exports->Set(v8::String::NewSymbol("booted"), v8::FunctionTemplate::New(booted)->GetFunction());
-        exports->Set(v8::String::NewSymbol("LISTEN_FDS_START"), v8::Integer::New(SD_LISTEN_FDS_START));
-    }
+    NanReturnValue(NanNew<Number>(res));
 }
 
-NODE_MODULE(daemon, daemon::init)
+void InitAll(Handle<Object> exports) {
+    exports->Set(NanNew<String>("notify"), NanNew<FunctionTemplate>(notify)->GetFunction());
+    exports->Set(NanNew<String>("booted"), NanNew<FunctionTemplate>(booted)->GetFunction());
+    exports->Set(NanNew<String>("LISTEN_FDS_START"), NanNew<Number>(SD_LISTEN_FDS_START));
+}
+
+NODE_MODULE(daemon, InitAll)

--- a/src/daemon.cc
+++ b/src/daemon.cc
@@ -25,7 +25,7 @@ NAN_METHOD(notify) {
         NanReturnUndefined();
     }
         
-    Utf8Value state(args[0]);
+    String::Utf8Value state(args[0]);
         
     const int res = sd_notify(0, *state);
 


### PR DESCRIPTION
I updated node-sd-daemon to be Node 0.12.0. Because the newer version of v8 has lots of changes that backwards compatibility I used nan module to maintain backwards compatibility within node-sd-daemon.

Sorry for the formatting changes but I used npm install --save nan which formatted package.json.